### PR TITLE
feat: use dumb-init as PID1 so as to reap zombies

### DIFF
--- a/dockerfiles/graph-toolbox/Dockerfile
+++ b/dockerfiles/graph-toolbox/Dockerfile
@@ -21,7 +21,8 @@ RUN apt-get -q update \
     gcc g++ make \
     postgresql \
     postgresql-contrib \
-    aria2
+    aria2 \
+    dumb-init
 
 RUN (curl -sL https://deb.nodesource.com/setup_16.x | bash -) && \
     apt-get install -y nodejs && \
@@ -34,4 +35,5 @@ ADD ./inner-readme README
 
 COPY --from=graphman-source /usr/local/bin/graphman /usr/local/bin/graphman
 
-ENTRYPOINT ["/bin/sleep", "infinity"]
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD ["bash", "-c", "/bin/sleep infinity"]


### PR DESCRIPTION
Current container runs sleep infinity as ENTRYPOINT (PID1). As is, whenever processes end up orphaned, they end up forever "defunct" as it happened to me running it on k8s:

```bash
root@node1 ~ # ps -e -o pid,comm,cgroup
.
.
.
3911383 node <defunct>  0::/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod41b1cfa5_c7b9_4ae8_8507_b0d93be4e8d9.slice/crio-2722d351ee4951d9d6842a37ec12e566acfa22dc07dfd7575323adaa3de9a157.scope
3911553 node <defunct>  0::/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod41b1cfa5_c7b9_4ae8_8507_b0d93be4e8d9.slice/crio-2722d351ee4951d9d6842a37ec12e566acfa22dc07dfd7575323adaa3de9a157.scope
3913030 node <defunct>  0::/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod41b1cfa5_c7b9_4ae8_8507_b0d93be4e8d9.slice/crio-2722d351ee4951d9d6842a37ec12e566acfa22dc07dfd7575323adaa3de9a157.scope
3913823 node <defunct>  0::/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod41b1cfa5_c7b9_4ae8_8507_b0d93be4e8d9.slice/crio-2722d351ee4951d9d6842a37ec12e566acfa22dc07dfd7575323adaa3de9a157.scope
3914138 node <defunct>  0::/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod41b1cfa5_c7b9_4ae8_8507_b0d93be4e8d9.slice/crio-2722d351ee4951d9d6842a37ec12e566acfa22dc07dfd7575323adaa3de9a157.scope
3943820 node <defunct>  0::/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod41b1cfa5_c7b9_4ae8_8507_b0d93be4e8d9.slice/crio-2722d351ee4951d9d6842a37ec12e566acfa22dc07dfd7575323adaa3de9a157.scope
3943947 node <defunct>  0::/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod41b1cfa5_c7b9_4ae8_8507_b0d93be4e8d9.slice/crio-2722d351ee4951d9d6842a37ec12e566acfa22dc07dfd7575323adaa3de9a157.scope
3944624 node <defunct>  0::/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod41b1cfa5_c7b9_4ae8_8507_b0d93be4e8d9.slice/crio-2722d351ee4951d9d6842a37ec12e566acfa22dc07dfd7575323adaa3de9a157.scope
3945329 node <defunct>  0::/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod41b1cfa5_c7b9_4ae8_8507_b0d93be4e8d9.slice/crio-2722d351ee4951d9d6842a37ec12e566acfa22dc07dfd7575323adaa3de9a157.scope
3945788 node <defunct>  0::/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod41b1cfa5_c7b9_4ae8_8507_b0d93be4e8d9.slice/crio-2722d351ee4951d9d6842a37ec12e566acfa22dc07dfd7575323adaa3de9a157.scope
3946036 node <defunct>  0::/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod41b1cfa5_c7b9_4ae8_8507_b0d93be4e8d9.slice/crio-2722d351ee4951d9d6842a37ec12e566acfa22dc07dfd7575323adaa3de9a157.scope
root@node1 ~ # crictl ps | grep 2722d
2722d351ee495       b654cc05a3a999e614c6fa14e60d7d93a5a1a6cdd17ab7b6c977aacae517eb87                                                              4 weeks ago         Running             toolbox                       0  
```

For reference, the readme.md from dumb-init is quite informative: https://github.com/Yelp/dumb-init