### PR TITLE
fix: update list of preconfigured tools

### DIFF
--- a/dockerfiles/graph-toolbox/inner-readme
+++ b/dockerfiles/graph-toolbox/inner-readme
@@ -2,7 +2,8 @@ Welcome to your Graph Indexer Toolbox container!
 
 In here the following tools are preconfigured:
 - `graphman`
-- `graph indexer`
+- `graph`
+- `graph-indexer indexer`
 - `psql`
 
 Do not rely on state persistence in this container. Ensure that any important scripts or configs are defined externally.


### PR DESCRIPTION
- `graph` is the tool to build/deploy a subgraph `@graphprotocol/graph-cli`
- `graph-indexer` is the tool to interact with indexer `@graphprotocol/indexer-cli`